### PR TITLE
[REFACTOR] HPNavigationController 화면 단위 별 NavigationItem Setting

### DIFF
--- a/App/Sources/Application/AppDelegate.swift
+++ b/App/Sources/Application/AppDelegate.swift
@@ -94,7 +94,6 @@ private extension AppDelegate {
             let loginDIContainer = LoginDIContainer()
             self.window = UIWindow(frame: UIScreen.main.bounds)
             self.window?.rootViewController = HPNavigationController(
-                navigationBarType: .none,
                 rootViewController: loginDIContainer.makeViewController(),
                 defaultBarAppearance: UINavigationBarAppearance(),
                 scrollBarAppearance: UINavigationBarAppearance()

--- a/App/Sources/Application/SceneDelegate.swift
+++ b/App/Sources/Application/SceneDelegate.swift
@@ -24,7 +24,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = .init(windowScene: scene)
         let loginDIContainer = LoginDIContainer()
         window?.rootViewController = HPNavigationController(
-            navigationBarType: .none,
             rootViewController: loginDIContainer.makeViewController(),
             defaultBarAppearance: UINavigationBarAppearance(),
             scrollBarAppearance: UINavigationBarAppearance()

--- a/App/Sources/Presentation/Main/TabBar/CustomTabBarController.swift
+++ b/App/Sources/Presentation/Main/TabBar/CustomTabBarController.swift
@@ -13,7 +13,6 @@ import HPCommonUI
 final class CustomTabBarController: UITabBarController, UITabBarControllerDelegate {
     
     private let homeController = HPNavigationController(
-        navigationBarType: .home,
         rootViewController: HomeDIContainer().makeViewController(),
         defaultBarAppearance: UINavigationBarAppearance(),
         scrollBarAppearance: UINavigationBarAppearance()

--- a/App/Sources/Presentation/Navigation/HPNavigationController.swift
+++ b/App/Sources/Presentation/Navigation/HPNavigationController.swift
@@ -11,16 +11,13 @@ import HPCommonUI
 import HPExtensions
 import Then
 import SnapKit
-
-public enum HPNavigationBarType: Equatable {
-    case home
-    case ticket
-    case lessonDetail
-    case none
-}
+import RxSwift
+import RxCocoa
 
 
 public protocol HPNavigationProxy {
+    
+    var disposeBag: DisposeBag { get }
     var rightBarButtonItems: [UIBarButtonItem] { get }
     var leftBarButtonItems: [UIBarButtonItem] { get }
     var scrollBarAppearance: UINavigationBarAppearance { get }
@@ -32,20 +29,17 @@ public protocol HPNavigationProxy {
 
 
 public final class HPNavigationController: UINavigationController, HPNavigationProxy {
-    
-    public private(set) var navigationBarType: HPNavigationBarType
-    
+        
+    public var disposeBag: DisposeBag = DisposeBag()
     public var defaultBarAppearance: UINavigationBarAppearance
     public var scrollBarAppearance: UINavigationBarAppearance
     public var rightBarButtonItems: [UIBarButtonItem] = []
     public var leftBarButtonItems: [UIBarButtonItem] = []
     
-    public init(navigationBarType: HPNavigationBarType,
-                rootViewController: UIViewController,
+    public init(rootViewController: UIViewController,
                 defaultBarAppearance: UINavigationBarAppearance,
                 scrollBarAppearance: UINavigationBarAppearance
     ) {
-        self.navigationBarType = navigationBarType
         self.defaultBarAppearance = defaultBarAppearance
         self.scrollBarAppearance = scrollBarAppearance
         super.init(rootViewController: rootViewController)
@@ -166,6 +160,12 @@ public final class HPNavigationController: UINavigationController, HPNavigationP
         customDotButtonItem.setImage(HPCommonUIAsset.dot.image.withRenderingMode(.alwaysOriginal), for: .normal)
         spacerbarButtonItem.width = 13
         
+        backButtonItem
+            .rx.tap
+            .bind(onNext: {
+                NotificationCenter.default.post(name: .popToViewController, object: nil)
+            }).disposed(by: disposeBag)
+        
         leftBarButtonItems = [
             UIBarButtonItem(customView: backButtonItem)
         ]
@@ -176,7 +176,6 @@ public final class HPNavigationController: UINavigationController, HPNavigationP
             UIBarButtonItem(customView: customDotButtonItem)
         ]
         
-        self.navigationItem.setHidesBackButton(<#T##hidesBackButton: Bool##Bool#>, animated: <#T##Bool#>)
         self.navigationBar.topItem?.leftBarButtonItems = leftBarButtonItems
         self.navigationBar.topItem?.rightBarButtonItems = rightBarButtonItems
         

--- a/App/Sources/Presentation/Navigation/HPNavigationController.swift
+++ b/App/Sources/Presentation/Navigation/HPNavigationController.swift
@@ -1,12 +1,13 @@
 //
 //  HPNavigationController.swift
-//  HPCommonUI
+//  Hobbyloop
 //
-//  Created by Kim dohyun on 2023/06/21.
+//  Created by Kim dohyun on 2023/09/22.
 //
 
 import UIKit
 
+import HPCommonUI
 import HPExtensions
 import Then
 import SnapKit
@@ -26,6 +27,7 @@ public protocol HPNavigationProxy {
     var defaultBarAppearance: UINavigationBarAppearance { get }
     func setHomeNavigationBarButtonItem() -> Void
     func setTicketNavigationBarButtonItem() -> Void
+    func setTicketDetailNavigationBarButtonItem() -> Void
 }
 
 
@@ -146,8 +148,38 @@ public final class HPNavigationController: UINavigationController, HPNavigationP
             searchbarButtonItem
         ]
         
+        self.navigationItem.setHidesBackButton(false, animated: true)
         self.navigationBar.topItem?.leftBarButtonItems = leftBarButtonItems
         self.navigationBar.topItem?.rightBarButtonItems = rightBarButtonItems
+        
+    }
+    
+    public func setTicketDetailNavigationBarButtonItem() {
+        let backButtonItem = UIButton(type: .system)
+        let bookMarkButtonItem = UIButton(type: .system)
+        let spacerbarButtonItem = UIBarButtonItem(systemItem: .fixedSpace)
+        let customDotButtonItem = UIButton(type: .system)
+        
+        
+        backButtonItem.setImage(HPCommonUIAsset.leftArrow.image.withRenderingMode(.alwaysOriginal), for: .normal)
+        bookMarkButtonItem.setImage(HPCommonUIAsset.unArchive.image.withRenderingMode(.alwaysOriginal), for: .normal)
+        customDotButtonItem.setImage(HPCommonUIAsset.dot.image.withRenderingMode(.alwaysOriginal), for: .normal)
+        spacerbarButtonItem.width = 13
+        
+        leftBarButtonItems = [
+            UIBarButtonItem(customView: backButtonItem)
+        ]
+        
+        rightBarButtonItems = [
+            UIBarButtonItem(customView: bookMarkButtonItem),
+            spacerbarButtonItem,
+            UIBarButtonItem(customView: customDotButtonItem)
+        ]
+        
+        self.navigationItem.setHidesBackButton(<#T##hidesBackButton: Bool##Bool#>, animated: <#T##Bool#>)
+        self.navigationBar.topItem?.leftBarButtonItems = leftBarButtonItems
+        self.navigationBar.topItem?.rightBarButtonItems = rightBarButtonItems
+        
         
     }
 }
@@ -156,18 +188,21 @@ public final class HPNavigationController: UINavigationController, HPNavigationP
 extension HPNavigationController: UINavigationControllerDelegate {
     
     public func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
-        //TODO: navigationBarType에 따라 NavigationBarButton Item 세팅
-        switch navigationBarType {
-        case .home:
+        
+        switch viewController {
+        case is HomeViewController:
             setHomeNavigationBarButtonItem()
-        case .ticket:
+        case is TicketViewController:
             setTicketNavigationBarButtonItem()
-        case .lessonDetail: break
-        case .none:
-            self.navigationItem.setHidesBackButton(true, animated: true)
+        case is TicketDetailViewController:
+            setTicketDetailNavigationBarButtonItem()
             
+        default:
+            configure()
         }
         
         
     }
 }
+
+

--- a/Core/HPExtensions/Sources/Notification+Extensions.swift
+++ b/Core/HPExtensions/Sources/Notification+Extensions.swift
@@ -1,0 +1,22 @@
+//
+//  Notification+Extensions.swift
+//  HPExtensions
+//
+//  Created by Kim dohyun on 2023/09/25.
+//
+
+import Foundation
+
+
+public extension Notification.Name {
+    
+    static let popToViewController = Notification.Name("popToViewController")
+    static let searchToViewController = Notification.Name("searchToViewController")
+    static let notiToViewController = Notification.Name("notiToViewController")
+    
+    
+    static let moreAction = Notification.Name("moreAction")
+    static let bookMarkAction = Notification.Name("bookMarkAction")
+    static let settingAction = Notification.Name("settingAction")
+    
+}

--- a/UI/HPCommonUI/Sources/Common/Calendar/Reactor/HPCalendarViewReactor.swift
+++ b/UI/HPCommonUI/Sources/Common/Calendar/Reactor/HPCalendarViewReactor.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+import HPExtensions
 import ReactorKit
 import RxSwift
 


### PR DESCRIPTION
## 📝 TO-DO
- [x] `UINavigationControllerDelegate` 대리자 Method를 사용하여 현재 보여지는 ViewController 에 따라 UI Configure

## 🧑‍💻 Description
- `navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool)` 에서 `didShow` Parameter 에 전달되는 ViewController 를 활용하여 UI Configure
- HPNavigationController 모듈 위치 변경
